### PR TITLE
Displacy renders and compares 'en_core_web_sm' to 'en_core_web_lg'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Clone or fork this repository, open a terminal window and in the directory where
 conda-env create .
 source activate etk2_env
 python -m spacy download en_core_web_sm
+python -m spacy download en_core_web_lg
 ```
 
 ## Run Tests

--- a/etk/doc_retrieve_processor.py
+++ b/etk/doc_retrieve_processor.py
@@ -50,8 +50,8 @@ class DocRetrieveProcessor(object):
                 'date': None,
                 'ifp': None,
                 'news_story': None,
-                'title': None,
-                'similarity': 0.0
+                'similarity': 0.0,
+                'matched_sentence': None
             }
 
         return self.etk.create_document(output_cdr_doc)

--- a/etk/doc_retrieve_processor.py
+++ b/etk/doc_retrieve_processor.py
@@ -30,6 +30,7 @@ class DocRetrieveProcessor(object):
         sentences = self.sentence_tokenizer_pattern.split(content)
 
         scores = list(map(self.query_tokens.similarity, list(map(self.nlp, sentences))))
+        # Note: ^ this is returning the cosSim of the AVERAGED .vectors in the list of tokens being compared
         max_score = max(scores)
         max_score_idx = scores.index(max_score)
         max_score_sentence = sentences[max_score_idx]
@@ -42,6 +43,18 @@ class DocRetrieveProcessor(object):
                 'news_story': doc_id,
                 'similarity': max_score,
                 'matched_sentence': max_score_sentence
+            }
+        else:
+            print('Max similarity score: {}'.format(max_score))
+            print('  Expected to be above {}'.format(threshold))
+            print('    Creating empty DocObj...')
+            output_cdr_doc = {
+                'type': None,
+                'date': None,
+                'ifp': None,
+                'news_story': None,
+                'title': None,
+                'similarity': 0.0
             }
 
         return self.etk.create_document(output_cdr_doc)
@@ -57,6 +70,7 @@ class DocRetrieveProcessor(object):
         title = json_obj['lexisnexis']['doc_title']
         title_token = self.nlp(title)
         similarity = self.query_tokens.similarity(title_token)
+        # Note: ^ this is returning the cosSim of the AVERAGED .vectors in the list of tokens being compared
 
         if similarity > threshold:
             output_obj = {
@@ -66,6 +80,18 @@ class DocRetrieveProcessor(object):
                 'news_story': doc_id,
                 'title': title,
                 'similarity': similarity
+            }
+        else:
+            print('Similarity score: {}'.format(similarity))
+            print('  Expected to be above {}'.format(threshold))
+            print('    Creating empty DocObj...')
+            output_obj = {
+                'type': None,
+                'date': None,
+                'ifp': None,
+                'news_story': None,
+                'title': None,
+                'similarity': 0.0
             }
 
         return self.etk.create_document(output_obj)

--- a/etk/doc_retrieve_processor.py
+++ b/etk/doc_retrieve_processor.py
@@ -45,9 +45,6 @@ class DocRetrieveProcessor(object):
                 'matched_sentence': max_score_sentence
             }
         else:
-            print('Max similarity score: {}'.format(max_score))
-            print('  Expected to be above {}'.format(threshold))
-            print('    Creating empty DocObj...')
             output_cdr_doc = {
                 'type': None,
                 'date': None,
@@ -82,9 +79,6 @@ class DocRetrieveProcessor(object):
                 'similarity': similarity
             }
         else:
-            print('Similarity score: {}'.format(similarity))
-            print('  Expected to be above {}'.format(threshold))
-            print('    Creating empty DocObj...')
             output_obj = {
                 'type': None,
                 'date': None,

--- a/notebooks/NER_with_displacy.ipynb
+++ b/notebooks/NER_with_displacy.ipynb
@@ -1,15 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
-   "source": [
-    ""
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -39,7 +30,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Load spacy build-in language model, create doc. Use en_core_web_sm for efficienty here."
+    "1) Load spaCy's built-in language model\n",
+    "\n",
+    "2) Create doc \n",
+    "\n",
+    "3) Compare outputs of language model using 'en_core_web_sm' and 'en_core_web_lg'"
    ]
   },
   {
@@ -48,7 +43,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nlp = spacy.load('en_core_web_sm')\n"
+    "nlp_sm = spacy.load('en_core_web_sm')\n",
+    "nlp_lg = spacy.load('en_core_web_lg')"
    ]
   },
   {
@@ -60,13 +56,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cuba victim's family wants shooter's assets seized - CNN #SmartNews Emotional \nJimmy Kimmel rips gun-control foes after Vegas shooting The Onion’s Las Vegas Shooting shooting https://t.co/aTPUnGvz9c mashable Controlled Chaos at Las Vegas Hospital Trauma Center shooting: Carla and Jae Unser hugged their children… YouTube changed its search algorithm after reports revealed it was surfacing inaccurate Stephen Paddock was 'upbeat, happy' as he bought guns\n"
+      "False\nTrue\nCuba victim's family wants shooter's assets seized - CNN #SmartNews Emotional \nJimmy Kimmel rips gun-control foes after Vegas shooting The Onion’s Las Vegas Shooting shooting https://t.co/aTPUnGvz9c mashable Controlled Chaos at Las Vegas Hospital Trauma Center shooting: Carla and Jae Unser hugged their children… YouTube changed its search algorithm after reports revealed it was surfacing inaccurate Stephen Paddock was 'upbeat, happy' as he bought guns\n"
      ]
     }
    ],
    "source": [
-    "doc = nlp(text)\n",
-    "print(doc)\n"
+    "doc_sm = nlp_sm(text)\n",
+    "doc_lg = nlp_lg(text)\n",
+    "\n",
+    "print(doc_sm == doc_lg)                 # Check if outputs are identical (should be False)\n",
+    "print(doc_sm.text == doc_lg.text)       # Check if text is identical (should be True)\n",
+    "print(doc_sm.text)\n"
    ]
   },
   {
@@ -83,7 +83,7 @@
     }
    ],
    "source": [
-    "for ent in doc.ents:\n",
+    "for ent in doc_sm.ents:\n",
     "    print(ent.text, ent.start_char, ent.end_char, ent.label_)"
    ]
   },
@@ -91,37 +91,298 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cuba 0 4 GPE\nCNN 53 56 ORG\n\nJimmy Kimmel 78 91 PERSON\nVegas 120 125 GPE\nOnion 139 144 NORP\nLas Vegas 147 156 GPE\nControlled Chaos 208 224 FAC\nLas Vegas Hospital Trauma Center 228 260 FAC\nCarla 271 276 PERSON\nJae Unser 281 290 PERSON\nYouTube 314 321 PERSON\nStephen Paddock 402 417 PERSON\n"
+     ]
+    }
+   ],
+   "source": [
+    "for ent in doc_lg.ents:\n",
+    "    print(ent.text, ent.start_char, ent.end_char, ent.label_)"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
-     "ename": "OSError",
-     "evalue": "[Errno 48] Address already in use",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mOSError\u001b[0m                                   Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-6-84a84f0a4ed2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mdisplacy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mserve\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdoc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstyle\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'ent'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/anaconda/envs/etk2_env/lib/python3.6/site-packages/spacy/displacy/__init__.py\u001b[0m in \u001b[0;36mserve\u001b[0;34m(docs, style, page, minify, options, manual, port)\u001b[0m\n\u001b[1;32m     58\u001b[0m     render(docs, style=style, page=page, minify=minify, options=options,\n\u001b[1;32m     59\u001b[0m            manual=manual)\n\u001b[0;32m---> 60\u001b[0;31m     \u001b[0mhttpd\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msimple_server\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmake_server\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'0.0.0.0'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mport\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mapp\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     61\u001b[0m     prints(\"Using the '{}' visualizer\".format(style),\n\u001b[1;32m     62\u001b[0m            title=\"Serving on port {}...\".format(port))\n",
-      "\u001b[0;32m~/anaconda/envs/etk2_env/lib/python3.6/wsgiref/simple_server.py\u001b[0m in \u001b[0;36mmake_server\u001b[0;34m(host, port, app, server_class, handler_class)\u001b[0m\n\u001b[1;32m    151\u001b[0m ):\n\u001b[1;32m    152\u001b[0m     \u001b[0;34m\"\"\"Create a new WSGI server listening on `host` and `port` for `app`\"\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 153\u001b[0;31m     \u001b[0mserver\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mserver_class\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mhost\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mport\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mhandler_class\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    154\u001b[0m     \u001b[0mserver\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mset_app\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mapp\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    155\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mserver\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda/envs/etk2_env/lib/python3.6/socketserver.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, server_address, RequestHandlerClass, bind_and_activate)\u001b[0m\n\u001b[1;32m    451\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mbind_and_activate\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    452\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 453\u001b[0;31m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mserver_bind\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    454\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mserver_activate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    455\u001b[0m             \u001b[0;32mexcept\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda/envs/etk2_env/lib/python3.6/wsgiref/simple_server.py\u001b[0m in \u001b[0;36mserver_bind\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     48\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mserver_bind\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     49\u001b[0m         \u001b[0;34m\"\"\"Override server_bind to store the server name.\"\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 50\u001b[0;31m         \u001b[0mHTTPServer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mserver_bind\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     51\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msetup_environ\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     52\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda/envs/etk2_env/lib/python3.6/http/server.py\u001b[0m in \u001b[0;36mserver_bind\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    134\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mserver_bind\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    135\u001b[0m         \u001b[0;34m\"\"\"Override server_bind to store the server name.\"\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 136\u001b[0;31m         \u001b[0msocketserver\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTCPServer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mserver_bind\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    137\u001b[0m         \u001b[0mhost\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mport\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mserver_address\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    138\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mserver_name\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msocket\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgetfqdn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mhost\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda/envs/etk2_env/lib/python3.6/socketserver.py\u001b[0m in \u001b[0;36mserver_bind\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    465\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mallow_reuse_address\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    466\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msocket\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msetsockopt\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msocket\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSOL_SOCKET\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msocket\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSO_REUSEADDR\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 467\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msocket\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbind\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mserver_address\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    468\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mserver_address\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msocket\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgetsockname\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    469\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mOSError\u001b[0m: [Errno 48] Address already in use"
-     ],
-     "output_type": "error"
+     "data": {
+      "text/html": [
+       "<div class=\"entities\" style=\"line-height: 2.5\">\n",
+       "<mark class=\"entity\" style=\"background: #feca74; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Cuba\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">GPE</span>\n",
+       "</mark>\n",
+       " victim's family wants shooter's assets seized - \n",
+       "<mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    CNN\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">ORG</span>\n",
+       "</mark>\n",
+       " #\n",
+       "<mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    SmartNews Emotional \n",
+       "\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">ORG</span>\n",
+       "</mark>\n",
+       "\n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Jimmy Kimmel\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " rips gun-control foes after Vegas shooting The \n",
+       "<mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Onion\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">ORG</span>\n",
+       "</mark>\n",
+       "’s \n",
+       "<mark class=\"entity\" style=\"background: #feca74; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Las Vegas\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">GPE</span>\n",
+       "</mark>\n",
+       " Shooting shooting https://t.co/aTPUnGvz9c mashable Controlled Chaos at \n",
+       "<mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Las Vegas Hospital Trauma Center\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">ORG</span>\n",
+       "</mark>\n",
+       " shooting: \n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Carla\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " and Jae Unser hugged their children… \n",
+       "<mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    YouTube\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">ORG</span>\n",
+       "</mark>\n",
+       " changed its search algorithm after reports revealed it was surfacing inaccurate \n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Stephen Paddock\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " was 'upbeat, happy' as he bought guns</div>"
+      ],
+      "text/plain": [
+       "<div class=\"entities\" style=\"line-height: 2.5\">\n",
+       "<mark class=\"entity\" style=\"background: #feca74; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Cuba\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">GPE</span>\n",
+       "</mark>\n",
+       " victim's family wants shooter's assets seized - \n",
+       "<mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    CNN\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">ORG</span>\n",
+       "</mark>\n",
+       " #\n",
+       "<mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    SmartNews Emotional \n",
+       "\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">ORG</span>\n",
+       "</mark>\n",
+       "\n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Jimmy Kimmel\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " rips gun-control foes after Vegas shooting The \n",
+       "<mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Onion\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">ORG</span>\n",
+       "</mark>\n",
+       "’s \n",
+       "<mark class=\"entity\" style=\"background: #feca74; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Las Vegas\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">GPE</span>\n",
+       "</mark>\n",
+       " Shooting shooting https://t.co/aTPUnGvz9c mashable Controlled Chaos at \n",
+       "<mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Las Vegas Hospital Trauma Center\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">ORG</span>\n",
+       "</mark>\n",
+       " shooting: \n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Carla\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " and Jae Unser hugged their children… \n",
+       "<mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    YouTube\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">ORG</span>\n",
+       "</mark>\n",
+       " changed its search algorithm after reports revealed it was surfacing inaccurate \n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Stephen Paddock\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " was 'upbeat, happy' as he bought guns</div>"
+      ]
+     },
+     "execution_count": 0,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "displacy.serve(doc, style='ent')"
+    "displacy.render(doc_sm, style='ent', jupyter=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"entities\" style=\"line-height: 2.5\">\n",
+       "<mark class=\"entity\" style=\"background: #feca74; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Cuba\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">GPE</span>\n",
+       "</mark>\n",
+       " victim's family wants shooter's assets seized - \n",
+       "<mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    CNN\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">ORG</span>\n",
+       "</mark>\n",
+       " #SmartNews Emotional \n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    \n",
+       "Jimmy Kimmel\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " rips gun-control foes after \n",
+       "<mark class=\"entity\" style=\"background: #feca74; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Vegas\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">GPE</span>\n",
+       "</mark>\n",
+       " shooting The \n",
+       "<mark class=\"entity\" style=\"background: #c887fb; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Onion\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">NORP</span>\n",
+       "</mark>\n",
+       "’s \n",
+       "<mark class=\"entity\" style=\"background: #feca74; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Las Vegas\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">GPE</span>\n",
+       "</mark>\n",
+       " Shooting shooting https://t.co/aTPUnGvz9c mashable \n",
+       "<mark class=\"entity\" style=\"background: #ddd; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Controlled Chaos\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">FAC</span>\n",
+       "</mark>\n",
+       " at \n",
+       "<mark class=\"entity\" style=\"background: #ddd; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Las Vegas Hospital Trauma Center\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">FAC</span>\n",
+       "</mark>\n",
+       " shooting: \n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Carla\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " and \n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Jae Unser\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " hugged their children… \n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    YouTube\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " changed its search algorithm after reports revealed it was surfacing inaccurate \n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Stephen Paddock\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " was 'upbeat, happy' as he bought guns</div>"
+      ],
+      "text/plain": [
+       "<div class=\"entities\" style=\"line-height: 2.5\">\n",
+       "<mark class=\"entity\" style=\"background: #feca74; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Cuba\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">GPE</span>\n",
+       "</mark>\n",
+       " victim's family wants shooter's assets seized - \n",
+       "<mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    CNN\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">ORG</span>\n",
+       "</mark>\n",
+       " #SmartNews Emotional \n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    \n",
+       "Jimmy Kimmel\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " rips gun-control foes after \n",
+       "<mark class=\"entity\" style=\"background: #feca74; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Vegas\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">GPE</span>\n",
+       "</mark>\n",
+       " shooting The \n",
+       "<mark class=\"entity\" style=\"background: #c887fb; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Onion\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">NORP</span>\n",
+       "</mark>\n",
+       "’s \n",
+       "<mark class=\"entity\" style=\"background: #feca74; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Las Vegas\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">GPE</span>\n",
+       "</mark>\n",
+       " Shooting shooting https://t.co/aTPUnGvz9c mashable \n",
+       "<mark class=\"entity\" style=\"background: #ddd; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Controlled Chaos\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">FAC</span>\n",
+       "</mark>\n",
+       " at \n",
+       "<mark class=\"entity\" style=\"background: #ddd; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Las Vegas Hospital Trauma Center\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">FAC</span>\n",
+       "</mark>\n",
+       " shooting: \n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Carla\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " and \n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Jae Unser\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " hugged their children… \n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    YouTube\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " changed its search algorithm after reports revealed it was surfacing inaccurate \n",
+       "<mark class=\"entity\" style=\"background: #aa9cfc; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em; box-decoration-break: clone; -webkit-box-decoration-break: clone\">\n",
+       "    Stephen Paddock\n",
+       "    <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; text-transform: uppercase; vertical-align: middle; margin-left: 0.5rem\">PERSON</span>\n",
+       "</mark>\n",
+       " was 'upbeat, happy' as he bought guns</div>"
+      ]
+     },
+     "execution_count": 0,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "displacy.render(doc_lg, style='ent', jupyter=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Fixed last line with displacy.render(..., jupyter=True) so notebook will display labeled ents in PyCharm. Shows difference in outputs of spaCy's pertained language models when using 'en_core_web_sm' or 'en_core_web_lg'. 