### PR TITLE
Remove warning for no ontology input

### DIFF
--- a/etk/document.py
+++ b/etk/document.py
@@ -44,8 +44,6 @@ class Document(Segment):
             self.kg = None
             if not self.etk.kg_schema:
                 self.etk.log("Schema not found.", "warning", self.doc_id, self.url)
-        if not self.etk.ontology:
-            self.etk.log("Ontology not found.", "warning", self.doc_id, self.url)
         self._provenance_id_index = 0
         self._provenances = dict()
         self._jsonpath_provenances = dict()

--- a/etk/ontology_api.py
+++ b/etk/ontology_api.py
@@ -687,7 +687,7 @@ class Ontology(object):
 
 def rdf_generation(kg_object) -> str:
     """
-    Covert input knowledge graph object into n-triples RDF
+    Convert input knowledge graph object into n-triples RDF
 
     :param kg_object: str, dict, or json object
     :return: n-triples RDF in str


### PR DESCRIPTION
1. Remove warning for no ontology input;
2. Update the example of create kg with ontology, which now generate one JSON-lines file and one n-triples output;
3. Fix a typo.