### PR TITLE
Add granularity to metadata of time series

### DIFF
--- a/etk/timeseries/extract_spreadsheet.py
+++ b/etk/timeseries/extract_spreadsheet.py
@@ -54,7 +54,7 @@ class SpreadsheetAnnotation(object):
 
         time_coords = {}
         time_coords['locs'] = self.locparser.parse_range(tsr_json['times']['locs'])
-        time_coords['granularity'] = tsr_json['times']['granularity']
+        time_coords['granularity'] = tsr_json['times']['granularity'] if 'granularity' in tsr_json['times'] else 'unknown'
         if 'mode' in tsr_json['times']:
             time_coords['mode'] = tsr_json['times']['mode']
         else:

--- a/etk/timeseries/time_series_region.py
+++ b/etk/timeseries/time_series_region.py
@@ -202,6 +202,7 @@ class TimeSeriesRegion(object):
             timeseries = []
             ts_metadata = copy.deepcopy(metadata)
             ts_metadata['provenance'][self.orientation] = ts_idx
+            ts_metadata['granularity']=self.time_coordinates['granularity']
 
             try:
                 md_modes = self.parse_tsr_metadata(ts_metadata, data, ts_idx)

--- a/etk/unit_tests/test_timeseries_processor.py
+++ b/etk/unit_tests/test_timeseries_processor.py
@@ -18,6 +18,7 @@ class TestTimeseriesProcessor(unittest.TestCase):
         selected_docs = docs[1]
         expected_metadata = {
             "name": "AVERAGE DIESEL (AUTOMATIVE GAS OIL) PRICES/ Litre NGN",
+            "granularity":"monthly",
             "provenance": {
                 "filename": "DIESEL_june_2017.xlsx",
                 "sheet": 0,
@@ -26,7 +27,7 @@ class TestTimeseriesProcessor(unittest.TestCase):
             "location": "Abuja",
             "yearly_change": "23.776223776223777",
             "monthly_change": "6.3701923076923075",
-            "uid": "4ecb3b5cc3f65edf53550ddc2966684203706d9d"
+            "uid": "5e8c87d3d291944f01f6084c5dee223ee31746e2"
         }
         expected_ts = [('2016-09-01', 189.5),
                        ('2016-10-01', 180),


### PR DESCRIPTION
If granularity is present in time coordinate metadata, this granularity will be included in the metadata for the timeseries for use in downstream applications