### PR TITLE
Removing jupyter from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,4 +51,3 @@ pyexcel-io>=0.5.6
 pyexcel-xls>=0.5.6
 pyexcel-xlsx>=0.5.6
 SPARQLWrapper>=1.8.2
-jupyter 


### PR DESCRIPTION
I don't believe that jupyter is actually required to use etk, so removing it. It brings in a decent number of packages transitively, which makes our docker build slow.