### PR TITLE
Update table_extractor.py

### DIFF
--- a/etk/extractors/table_extractor.py
+++ b/etk/extractors/table_extractor.py
@@ -290,7 +290,7 @@ class TableExtraction:
                     
                     for i, c in enumerate(row.findAll(['td', 'th'])):
                         ci = i+shift+rshift
-                        if ci in row_spans:
+                        while ci in row_spans:
                             if row_spans[ci] <= 0:
                                 del row_spans[ci]
                             else:


### PR DESCRIPTION
fixes the bug in cases where there are multiple row-spans in a table row. in case of multiple row spans, shifting should apply to all of them. 